### PR TITLE
Fix score display when paused and update font

### DIFF
--- a/game.js
+++ b/game.js
@@ -73,6 +73,7 @@ function setup() {
   const canvas = createCanvas(320, 480);
   canvas.id('gameCanvas');
   canvas.parent(document.body);
+  textFont('Press Start 2P');
   audioCtx = new (window.AudioContext || window.webkitAudioContext)();
   restartGame();
   createCity();
@@ -338,7 +339,7 @@ function togglePause() {
 }
 
 function drawScore() {
-  fill('#000');
+  fill('#0f0');
   noStroke();
   textSize(24);
   textStyle(BOLD);
@@ -374,6 +375,7 @@ function draw() {
     textSize(32);
     textAlign(CENTER, CENTER);
     text('PAUSED', width / 2, height / 2);
+    drawScore();
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Flappy Bird</title>
+<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 <style>
   body {
     margin: 0;


### PR DESCRIPTION
## Summary
- keep the score visible while paused
- add an arcade-like font and use green score text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68508a471db4832faafaef9bedb90b00