### PR TITLE
Fix score display during pause

### DIFF
--- a/game.js
+++ b/game.js
@@ -341,9 +341,10 @@ function togglePause() {
 function drawScore() {
   fill('#0f0');
   noStroke();
-  textSize(24);
+  textSize(32); // larger score display
   textStyle(BOLD);
-  text(`Score: ${score}`, 10, 25);
+  textAlign(LEFT, TOP); // ensure consistent alignment after pausing
+  text(`Score: ${score}`, 10, 10);
 }
 
 function draw() {


### PR DESCRIPTION
## Summary
- ensure the score text always aligns to the upper left
- enlarge score font size

## Testing
- `node -c game.js`

------
https://chatgpt.com/codex/tasks/task_e_68508c16d1f8832f8eee9752ea2e2712